### PR TITLE
Feature/orchestrator logic

### DIFF
--- a/osi/src/app/app.component.html
+++ b/osi/src/app/app.component.html
@@ -13,4 +13,5 @@
       <app-endpoint [endpoint]="receiver" [displayName]="'Odbiorca'"></app-endpoint>
     </div>
   </div>
+  <app-logger [enabled]="true"></app-logger>
 </div>

--- a/osi/src/app/app.module.ts
+++ b/osi/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { NetworkLayerComponent } from './osi-container/network-layer/network-lay
 import { DatalinkLayerComponent } from './osi-container/datalink-layer/datalink-layer.component';
 import { PhysicalLayerComponent } from './osi-container/physical-layer/physical-layer.component';
 import { OrchestratorService } from './orchestrator.service';
+import { LoggerComponent } from './logger/logger.component';
 
 @NgModule({
   declarations: [
@@ -29,7 +30,8 @@ import { OrchestratorService } from './orchestrator.service';
     TransportLayerComponent,
     NetworkLayerComponent,
     DatalinkLayerComponent,
-    PhysicalLayerComponent
+    PhysicalLayerComponent,
+    LoggerComponent
   ],
   imports: [
     BrowserModule,

--- a/osi/src/app/domain/layers.ts
+++ b/osi/src/app/domain/layers.ts
@@ -15,6 +15,33 @@ export interface LayerId {
   readonly direction: Direction;
 }
 
-export interface LayerData {
+export interface DataBlock {
   readonly bytes: number[];
+}
+
+export interface LayerData {
+  readonly blocks: DataBlock[];
+}
+
+export function orderFor(direction: Direction): LayerKind[] {
+  const senderOrder = [
+    LayerKind.Application,
+    LayerKind.Presentation,
+    LayerKind.Session,
+    LayerKind.Transport,
+    LayerKind.Network,
+    LayerKind.DataLink,
+    LayerKind.Physical
+  ];
+
+  switch (direction) {
+    case Direction.Sender:
+      return senderOrder;
+
+    case Direction.Receiver:
+      return senderOrder.reverse();
+
+    default:
+      throw new Error(`Unknown value: '${direction} for the 'Direction'.`);
+  }
 }

--- a/osi/src/app/domain/layers/stream.ts
+++ b/osi/src/app/domain/layers/stream.ts
@@ -1,0 +1,77 @@
+import { Subject } from 'rxjs/Subject';
+
+import { Direction } from '../directions';
+import { LayerKind, LayerId, LayerData, orderFor } from '../layers';
+
+export class LayersStream {
+  private readonly map: LayersMap;
+  readonly head: StreamElement;
+
+  constructor() {
+    const receiverPart = generateFor(Direction.Receiver, null);
+    const senderPart = generateFor(Direction.Sender, receiverPart.head);
+
+    const map = {};
+    map[Direction.Receiver] = receiverPart.map;
+    map[Direction.Sender] = senderPart.map;
+    this.map = map;
+
+    this.head = senderPart.head;
+  }
+
+  for(layerId: LayerId): StreamElement {
+    return this.map[layerId.direction][layerId.kind];
+  }
+
+  downstreamFrom(layerId: LayerId): StreamElement {
+    return this.for(layerId).downstream;
+  }
+}
+
+export class StreamElement {
+  private readonly id: LayerId;
+  readonly downstream: StreamElement;
+  readonly dataSubject: Subject<LayerData>;
+  readonly clearFromSubject: Subject<{}>;
+
+  constructor(id: LayerId, downstream: StreamElement = null) {
+    this.id = id;
+    this.downstream = downstream;
+    this.dataSubject = new Subject<LayerData>();
+    this.clearFromSubject = new Subject();
+
+    if (downstream !== null) {
+      this.clearFromSubject.subscribe(downstream.clearFromSubject.next);
+    }
+  }
+}
+
+interface LayersMap {
+  readonly [direction: number]: PartMap;
+}
+
+interface PartMap {
+  readonly [layer: number]: StreamElement;
+}
+
+interface Part {
+  readonly head: StreamElement;
+  readonly map: PartMap;
+}
+
+function generateFor(direction: Direction, previous: StreamElement): Part {
+  const map = {};
+
+  for (const layer of orderFor(direction).reverse()) {
+    const id: LayerId = { kind: layer, direction: direction };
+    const element = new StreamElement(id, previous);
+
+    map[layer] = element;
+    previous = element;
+  }
+
+  return {
+    head: previous,
+    map: map
+  };
+}

--- a/osi/src/app/domain/layers/stream.ts
+++ b/osi/src/app/domain/layers/stream.ts
@@ -5,7 +5,7 @@ import { LayerKind, LayerId, LayerData, orderFor } from '../layers';
 
 export class LayersStream {
   private readonly map: LayersMap;
-  readonly head: StreamElement;
+  readonly headId: LayerId;
 
   constructor() {
     const receiverPart = generateFor(Direction.Receiver, null);
@@ -16,25 +16,25 @@ export class LayersStream {
     map[Direction.Sender] = senderPart.map;
     this.map = map;
 
-    this.head = senderPart.head;
+    this.headId = senderPart.head.id;
   }
 
-  for(layerId: LayerId): StreamElement {
+  for(layerId: LayerId): StreamLayer {
     return this.map[layerId.direction][layerId.kind];
   }
 
-  downstreamFrom(layerId: LayerId): StreamElement {
+  downstreamFrom(layerId: LayerId): StreamLayer {
     return this.for(layerId).downstream;
   }
 }
 
-export class StreamElement {
-  private readonly id: LayerId;
-  readonly downstream: StreamElement;
+export class StreamLayer {
+  readonly id: LayerId;
+  readonly downstream: StreamLayer;
   readonly dataSubject: Subject<LayerData>;
   readonly clearFromSubject: Subject<{}>;
 
-  constructor(id: LayerId, downstream: StreamElement = null) {
+  constructor(id: LayerId, downstream: StreamLayer = null) {
     this.id = id;
     this.downstream = downstream;
     this.dataSubject = new Subject<LayerData>();
@@ -51,20 +51,20 @@ interface LayersMap {
 }
 
 interface PartMap {
-  readonly [layer: number]: StreamElement;
+  readonly [layer: number]: StreamLayer;
 }
 
 interface Part {
-  readonly head: StreamElement;
+  readonly head: StreamLayer;
   readonly map: PartMap;
 }
 
-function generateFor(direction: Direction, previous: StreamElement): Part {
+function generateFor(direction: Direction, previous: StreamLayer): Part {
   const map = {};
 
   for (const layer of orderFor(direction).reverse()) {
     const id: LayerId = { kind: layer, direction: direction };
-    const element = new StreamElement(id, previous);
+    const element = new StreamLayer(id, previous);
 
     map[layer] = element;
     previous = element;

--- a/osi/src/app/domain/layers/stream.ts
+++ b/osi/src/app/domain/layers/stream.ts
@@ -41,7 +41,7 @@ export class StreamLayer {
     this.clearFromSubject = new Subject();
 
     if (downstream !== null) {
-      this.clearFromSubject.subscribe(downstream.clearFromSubject.next);
+      this.clearFromSubject.subscribe(_ => downstream.clearFromSubject.next());
     }
   }
 }

--- a/osi/src/app/file-loader/file-loader.component.ts
+++ b/osi/src/app/file-loader/file-loader.component.ts
@@ -45,7 +45,7 @@ export class FileLoaderComponent implements OnInit, OnDestroy {
       this.fileText = fileContent;
       log('onloaded', fileContent);
 
-      this.orchestrator.dataReady(contentToData(this.reader));
+      this.orchestrator.initializeFlow(contentToData(this.reader));
     };
   }
 }

--- a/osi/src/app/file-loader/file-loader.component.ts
+++ b/osi/src/app/file-loader/file-loader.component.ts
@@ -16,7 +16,7 @@ export class FileLoaderComponent implements OnInit, OnDestroy {
   fileText: string;
   alertText: string;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {}
   ngOnDestroy() {}

--- a/osi/src/app/file-loader/file-loader.component.ts
+++ b/osi/src/app/file-loader/file-loader.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 
 import { OrchestratorService } from '../orchestrator.service';
-import { LayerData } from '../domain/layers';
+import { DataBlock } from '../domain/layers';
 
 @Component({
   selector: 'app-file-loader',
@@ -45,12 +45,12 @@ export class FileLoaderComponent implements OnInit, OnDestroy {
       this.fileText = fileContent;
       log('onloaded', fileContent);
 
-      this.orchestrator.inputReady(contentToBytes(this.reader));
+      this.orchestrator.dataReady(contentToData(this.reader));
     };
   }
 }
 
-function contentToBytes(reader: FileReader): LayerData {
+function contentToData(reader: FileReader): DataBlock {
   // TODO: Load data as bytes, use encoding?
   return { bytes: [] };
 }

--- a/osi/src/app/logger/logger.component.html
+++ b/osi/src/app/logger/logger.component.html
@@ -1,0 +1,21 @@
+<section *ngIf="enabled && !onlyConsole" class="events-log">
+  <hr>
+  <header>Events log</header>
+  <section class="config">
+    <label>
+      <input [(ngModel)]="stringifyData" type="checkbox"> Stringify log's data / content?
+    </label>
+    <button (click)="clear()" class="clear">Clear log</button>
+    <button (click)="hide()" class="hide">Hide (still at `console`)</button>
+  </section>
+  <section class="entries">
+    <ol>
+      <li *ngFor="let entry of entries">
+        <b>{{entry.header}}</b>
+        <pre *ngIf="entry.body">
+          {{entry.body}}
+        </pre>
+      </li>
+    </ol>
+  </section>
+</section>

--- a/osi/src/app/logger/logger.component.spec.ts
+++ b/osi/src/app/logger/logger.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoggerComponent } from './logger.component';
+
+describe('LoggerComponent', () => {
+  let component: LoggerComponent;
+  let fixture: ComponentFixture<LoggerComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ LoggerComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(LoggerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/osi/src/app/logger/logger.component.ts
+++ b/osi/src/app/logger/logger.component.ts
@@ -1,0 +1,72 @@
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
+
+import {
+  OrchestratorService,
+  LogEntry,
+  LogEvent
+} from '../orchestrator.service';
+import { Subscription } from 'rxjs/Subscription';
+import { tick } from '@angular/core/testing';
+
+export interface LogItem {
+  readonly header: string;
+  readonly body?: string;
+}
+
+@Component({
+  selector: 'app-logger',
+  templateUrl: './logger.component.html',
+  styleUrls: ['./logger.component.css']
+})
+export class LoggerComponent implements OnInit, OnDestroy {
+  private readonly subscription: Subscription;
+  @Input() enabled: boolean;
+  @Input() onlyConsole = false;
+  @Input() stringifyData = true;
+  entries: LogItem[] = [];
+
+  constructor(private readonly orchestrator: OrchestratorService) {
+    this.subscription = orchestrator
+      .registerLogger()
+      .subscribe(entry => this.handleLog(entry));
+  }
+
+  ngOnInit() {}
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+
+  clear() {
+    this.entries = [];
+  }
+
+  hide() {
+    this.onlyConsole = true;
+    this.clear();
+  }
+
+  private handleLog(entry: LogEntry) {
+    if (!this.enabled) {
+      return;
+    }
+
+    // tslint:disable-next-line:no-console
+    console.info('# Event Log: ' + makeHeader(entry.event), entry.data);
+
+    this.entries.push({
+      header: makeHeader(entry.event),
+      body: this.stringifyData ? JSON.stringify(entry.data) : undefined
+    });
+  }
+}
+
+function makeHeader(event: LogEvent): string {
+  const time = new Date(Date.now());
+  return (
+    time.toLocaleTimeString() +
+    '.' +
+    time.getMilliseconds() +
+    ' | ' +
+    LogEvent[event]
+  );
+}

--- a/osi/src/app/orchestrator.service.ts
+++ b/osi/src/app/orchestrator.service.ts
@@ -38,11 +38,7 @@ export class OrchestratorService {
   private isWaiting = false;
   private behavior = NavigatorBehavior.AutoContinue;
 
-  registerLayer(layerId: LayerId): Observable<LayerData> {
-    return this.registerLayer_new(layerId).layerData;
-  }
-
-  registerLayer_new(layerId: LayerId): LayerObservables {
+  registerLayer(layerId: LayerId): LayerObservables {
     const layer = this.layersStream.for(layerId);
 
     return {
@@ -127,4 +123,13 @@ export class OrchestratorService {
       progress: Progress.Finished
     });
   }
+}
+
+export function registerDummyRepeater(
+  layerId: LayerId,
+  orchestrator: OrchestratorService
+): Subscription {
+  return orchestrator
+    .registerLayer(layerId)
+    .layerData.subscribe(data => orchestrator.ready(layerId, data));
 }

--- a/osi/src/app/orchestrator.service.ts
+++ b/osi/src/app/orchestrator.service.ts
@@ -1,33 +1,130 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
+import { Subscription } from 'rxjs/Subscription';
 
 import { Direction } from './domain/directions';
-import { LayerKind, LayerId, LayerData } from './domain/layers';
+import { LayerKind, LayerId, DataBlock, LayerData } from './domain/layers';
+import { LayersStream, StreamElement } from './domain/layers/stream';
 
-export enum NavigatorAction {
+export enum NavigatorBehavior {
   AutoContinue,
   BreakOnNext
 }
 
+export enum Progress {
+  Beginning,
+  LayerStep,
+  Finished
+}
+
+export interface ProgressData {
+  progress: Progress;
+  layerId?: LayerId;
+}
+
+export interface LayerObservables {
+  readonly clearStream: Observable<{}>;
+  readonly layerData: Observable<LayerData>;
+}
+
 @Injectable()
 export class OrchestratorService {
-  private readyLayers = new Subject<LayerId>();
-  private layersData = new Subject<LayerData>();
+  private readonly progressSubject = new Subject<ProgressData>();
+  private readonly layersStream = new LayersStream();
 
-  constructor() {}
+  private currentLayerId: LayerId;
+  private currentData: LayerData;
+  private isWaiting = false;
+  private behavior = NavigatorBehavior.AutoContinue;
 
   registerLayer(layerId: LayerId): Observable<LayerData> {
-    return this.layersData.asObservable();
+    return this.registerLayer_new(layerId).layerData;
   }
 
-  registerNavigator(): Observable<LayerId> {
-    return this.readyLayers.asObservable();
+  registerLayer_new(layerId: LayerId): LayerObservables {
+    const layer = this.layersStream.for(layerId);
+
+    return {
+      clearStream: layer.clearFromSubject.asObservable(),
+      layerData: layer.dataSubject.asObservable()
+    };
   }
 
-  navigate(action: NavigatorAction) {}
+  registerNavigator(): Observable<ProgressData> {
+    return this.progressSubject.asObservable();
+  }
 
-  inputReady(data: LayerData) {}
+  dataReady(data: DataBlock) {
+    this.layersStream.head.clearFromSubject.next();
+    this.layersStream.head.dataSubject.next({ blocks: [data] });
+    this.notifyBeginning();
+  }
 
-  ready(layerId: LayerId, data: LayerData) {}
+  navigate(action: NavigatorBehavior) {
+    switch (action) {
+      case NavigatorBehavior.BreakOnNext:
+      case NavigatorBehavior.AutoContinue:
+        this.behavior = action;
+        break;
+
+      default:
+        throw new Error(`Unknown kind of behavior: '${this.behavior}'.`);
+    }
+
+    if (this.isWaiting) {
+      this.pushIntoDownstream();
+    }
+  }
+
+  ready(layerId: LayerId, data: LayerData) {
+    this.currentLayerId = layerId;
+    this.currentData = data;
+    this.isWaiting = true;
+
+    this.notifyProgressStep();
+    this.clearFromCurrent();
+
+    if (this.behavior === NavigatorBehavior.AutoContinue) {
+      this.pushIntoDownstream();
+    }
+  }
+
+  private pushIntoDownstream() {
+    this.isWaiting = false;
+    const downstreamLayer = this.currentDownstream();
+
+    if (downstreamLayer !== null) {
+      downstreamLayer.dataSubject.next(this.currentData);
+    } else {
+      this.notifyFinished();
+    }
+  }
+
+  private currentDownstream(): StreamElement {
+    return this.layersStream.downstreamFrom(this.currentLayerId);
+  }
+
+  private clearFromCurrent() {
+    this.layersStream.for(this.currentLayerId).clearFromSubject.next();
+  }
+
+  private notifyBeginning() {
+    this.progressSubject.next({
+      progress: Progress.Beginning
+    });
+  }
+
+  private notifyProgressStep() {
+    this.progressSubject.next({
+      progress: Progress.LayerStep,
+      layerId: this.currentLayerId
+    });
+  }
+
+  private notifyFinished() {
+    this.progressSubject.next({
+      progress: Progress.Finished
+    });
+  }
 }

--- a/osi/src/app/osi-container/application-layer/application-layer.component.ts
+++ b/osi/src/app/osi-container/application-layer/application-layer.component.ts
@@ -17,7 +17,7 @@ export class ApplicationLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(

--- a/osi/src/app/osi-container/application-layer/application-layer.component.ts
+++ b/osi/src/app/osi-container/application-layer/application-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class ApplicationLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Application,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class ApplicationLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/datalink-layer/datalink-layer.component.ts
+++ b/osi/src/app/osi-container/datalink-layer/datalink-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class DatalinkLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.DataLink,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class DatalinkLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/datalink-layer/datalink-layer.component.ts
+++ b/osi/src/app/osi-container/datalink-layer/datalink-layer.component.ts
@@ -17,7 +17,7 @@ export class DatalinkLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(

--- a/osi/src/app/osi-container/network-layer/network-layer.component.ts
+++ b/osi/src/app/osi-container/network-layer/network-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class NetworkLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Network,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class NetworkLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/network-layer/network-layer.component.ts
+++ b/osi/src/app/osi-container/network-layer/network-layer.component.ts
@@ -17,7 +17,7 @@ export class NetworkLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(

--- a/osi/src/app/osi-container/physical-layer/physical-layer.component.ts
+++ b/osi/src/app/osi-container/physical-layer/physical-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 import { PhysicalLayer } from '../../domain/layers/physical';
@@ -24,12 +27,13 @@ export class PhysicalLayerComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Physical,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -47,6 +51,4 @@ export class PhysicalLayerComponent implements OnInit, OnDestroy {
   getFormat(): string {
     return Format[this.layer.displayFormat];
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/physical-layer/physical-layer.component.ts
+++ b/osi/src/app/osi-container/physical-layer/physical-layer.component.ts
@@ -20,7 +20,7 @@ export class PhysicalLayerComponent implements OnInit, OnDestroy {
   readonly layer: PhysicalLayer;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {
+  constructor(private readonly orchestrator: OrchestratorService) {
     this.layer = new PhysicalLayer();
     this.layer.bytesBlockSize = 8;
     this.layer.displayFormat = Format.Hexadecimal;

--- a/osi/src/app/osi-container/presentation-layer/presentation-layer.component.ts
+++ b/osi/src/app/osi-container/presentation-layer/presentation-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class PresentationLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Presentation,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class PresentationLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/presentation-layer/presentation-layer.component.ts
+++ b/osi/src/app/osi-container/presentation-layer/presentation-layer.component.ts
@@ -17,7 +17,7 @@ export class PresentationLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(

--- a/osi/src/app/osi-container/session-layer/session-layer.component.ts
+++ b/osi/src/app/osi-container/session-layer/session-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class SessionLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Session,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class SessionLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/session-layer/session-layer.component.ts
+++ b/osi/src/app/osi-container/session-layer/session-layer.component.ts
@@ -17,7 +17,7 @@ export class SessionLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(

--- a/osi/src/app/osi-container/transport-layer/transport-layer.component.ts
+++ b/osi/src/app/osi-container/transport-layer/transport-layer.component.ts
@@ -1,7 +1,10 @@
 import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs/Subscription';
 
-import { OrchestratorService } from '../../orchestrator.service';
+import {
+  OrchestratorService,
+  registerDummyRepeater
+} from '../../orchestrator.service';
 import { Direction, translateDirection } from '../../domain/directions';
 import { LayerKind, LayerData, LayerId } from '../../domain/layers';
 
@@ -17,12 +20,13 @@ export class TransportLayerComponent implements OnInit, OnDestroy {
   constructor(private orchestrator: OrchestratorService) {}
 
   ngOnInit() {
-    this.subscription = this.orchestrator
-      .registerLayer({
+    this.subscription = registerDummyRepeater(
+      {
         kind: LayerKind.Transport,
         direction: this.direction
-      })
-      .subscribe(this.handleDate);
+      },
+      this.orchestrator
+    );
   }
 
   ngOnDestroy() {
@@ -32,6 +36,4 @@ export class TransportLayerComponent implements OnInit, OnDestroy {
   getModeName() {
     return translateDirection(this.direction);
   }
-
-  private handleDate(data: LayerData) {}
 }

--- a/osi/src/app/osi-container/transport-layer/transport-layer.component.ts
+++ b/osi/src/app/osi-container/transport-layer/transport-layer.component.ts
@@ -17,7 +17,7 @@ export class TransportLayerComponent implements OnInit, OnDestroy {
   private subscription: Subscription;
   @Input() direction: Direction;
 
-  constructor(private orchestrator: OrchestratorService) {}
+  constructor(private readonly orchestrator: OrchestratorService) {}
 
   ngOnInit() {
     this.subscription = registerDummyRepeater(


### PR DESCRIPTION
  * `Orchestrator` knowns flow of data: Sender ->_ISO / OSI Model_ stack -> Receiver.
  * Each _layer_ register itself as simple `repeatr` - this will change when they become implemented.
  * There is no `Navigator` yet, but default `Orchestrator`'s behaviour is `AutoContinue`: will pass data from _one_ layer to _next one_ immediately.
  * At bottom of application located is the `logger`. It shows all `Orchestrator`'s events, and will dump more information. It always log into console (via `console.info()`). It do nothing when not `enabled`.

### How to implement a `LayerComponent`:
  * In a _Layer's_ `ngOnInit()` it should:
       * Subscribe to `clearStream` with handler for clearing itself when request comes.
       * Subscribe to `layerData` with handler for processing incoming `LayerData`.
  * Data processing handler should call `Orchestrator`'s method: `ready` with _Layer's ID_ and processed data for a next _Layer_.
       * It should also "rise this event" when _Layer's_ configuration is changes so that "output result" is different then "current state" (last data pushed downstream).
  * In a _Layer's_ `ngOnDestroy()` it should unsubscribe from all subscribed `Observable`. 